### PR TITLE
7 implement data preprocessing

### DIFF
--- a/src/arcsf/data/README.md
+++ b/src/arcsf/data/README.md
@@ -12,12 +12,41 @@ Dataset({
 ```
 
 #### Granularity
-There are 4 possible granularity options:
-- `'author_level'`
-  - Adds all questions from randomly chosen authors to the forget set. `forgotten_author_fraction (float)` should be passed.
-- `'structured_within_authors'`
-  - Adds $n$ questions from randomly chosen authors to the forget set. `forgotten_author_fraction` should be passed, $n$ is currently hard coded to 4.
-- `'random_within_authors'`
-  - Randomly adds a fraction of questions from randomly chosen authors to the forget set. `forgotten_author_fraction` should be passed as well as `forgotten_fact_fraction`.
-- `'random'`
-  - Randomly adds a percentage of questions across the entire dataset to the forget set. `forgotten_fact_fraction` should be passed.
+There are 4 possible granularity options, defined using three input arguments `granularity`, `forget_random`, and `stratified`.
+
+The first output is the forget set, and the second is the retain set.
+
+It can (hopefully) be integrated into the source code in the following way, using the Text:
+
+    class TextForgetDatasetQA(Dataset):
+        def __init__(self, data_path, tokenizer, model_family,  max_length=512, split = "forget10", loss_type="idk"):
+            super(TextForgetDatasetQA, self).__init__()
+            self.tokenizer = tokenizer
+            self.max_length = max_length
+            self.forget_data = datasets.load_dataset(data_path, split)["train"] # <<<< Replace with the `forget` output of load_tofu
+            retain_split = "retain" + str(100 - int(split.replace("forget", ""))).zfill(2)
+            self.retain_data =datasets.load_dataset(data_path, retain_split)["train"] # <<<< Replace with the `retain` output of load_tofu
+            self.model_configs = get_model_identifiers_from_yaml(model_family)
+            self.loss_type = loss_type
+
+            ...
+
+The `self.forget_data` and `self.retain_data` attributes should be replaced with those defined using `load_tofu`. There is no need to specify the `['train']` split, since the `load_tofu` function does not create a datasetDict (though there is scope to change this if necessary for improved integrability).
+
+
+## Data Module
+### `QAForgetSet`
+
+This is a `torch.utils.data.dataset` class which contains question answer pairs for forgetting. It has 4 attributes:
+- `tokenizer`: This is the tokenizer which is used convert the raw text into tokens
+- `loss_type`: This is the type of loss being used. If the desired outcome is "I don't know" or something to  that effect use the argument - `'idk'`.
+- `forget_data`: This is the forget data entries defined using `load_tofu`.
+- `idk`: If the loss_type is set to `'idk'` then this attribute is defined to correspond to a list of possible strings which are  used to replace the target answers.
+
+There are also a number of optional arguments in the `__init__()`, most of which are passed into the `load_tofu` call:
+  - `granularity`: Corresponds to the level of granularity in the forget set.
+  - `a_to_drop`: Defaults to 0.1, corresponds to the fraction of authors to randomly drop.
+  - `q_to_drop`: Defaults to 0.1, corresponds to the fraction of questions to randomly drop within author question sets.
+  - `random_seed`: Random seed for repeatability, defaults to 42, the answer to life.
+  - `tokenizer`: As above, the tokenizer should be passed to the class at initialisation.
+  - `loss_type`: As above, the type loss is defined in the class initialisation.

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -1,5 +1,5 @@
 import torch
-from torch.utils.data import Dataset
+from torch.utils.data import ConcatDataset, Dataset
 
 from arcsf.data.data_utils import load_tofu
 
@@ -39,12 +39,122 @@ class QADataSet(Dataset):
         return len(self.data)
 
     def __getitem__(self, idx):
-        input = self.qa_formatter(self.data[idx]["question"])
+        input = self.data[idx]["question"]
 
         if self.loss_type == "idk":
             rand_pos = torch.randint(0, len(self.idk), (1,)).item()
-            target = self.qa_formatter(self.idk[rand_pos])
+            target = self.idk[rand_pos]
         else:
-            target = self.qa_formatter(self.data[idx]["answer"])
+            target = self.data[idx]["answer"]
 
         return self.tokenizer(input), self.tokenizer(target)
+
+
+class FinetuneDataset(Dataset):
+    def __init__(
+        self,
+        tokenizer,
+        qa_formatter,
+        granularity,
+        split="forget",
+        a_to_drop=0.1,
+        q_to_drop=0.1,
+        loss_type="standard",
+        random_seed=42,
+    ):
+        super(FinetuneDataset, self).__init__()
+        self.tokenizer = tokenizer
+        self.qa_formatter = qa_formatter
+        self.loss_type = loss_type
+
+        forget_data, retain_data, self.debug_dict = load_tofu(
+            granularity,
+            forgotten_author_fraction=a_to_drop,
+            forgotten_fact_fraction=q_to_drop,
+            random_seed=random_seed,
+            debug=True,
+        )
+        split_dict = {
+            "retain": retain_data,
+            "forget": forget_data,
+            "all": ConcatDataset([retain_data, forget_data]),
+        }
+        self.data = split_dict[split]
+
+        if loss_type == "idk":
+            with open("src/arcsf/data/idk.jsonl") as idk_file:
+                self.idk = idk_file.read().splitlines()
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+
+        question = self.data[idx]["question"]
+        if self.loss_type == "idk":
+            rand_pos = torch.randint(0, len(self.idk), (1,)).item()
+            answer = self.qa_formatter(self.idk[rand_pos])
+        else:
+            answer = self.qa_formatter(self.data[idx]["answer"])
+
+        inp = self.qa_formatter(question, answer)
+
+        return self.tokenizer(inp)
+
+
+# should return all
+class QAForgetDataSet(Dataset):
+    def __init__(
+        self,
+        tokenizer,
+        qa_formatter,
+        granularity,
+        a_to_drop=0.1,
+        q_to_drop=0.1,
+        loss_type="standard",
+        random_seed=42,
+    ):
+        super(QAForgetDataSet, self).__init__()
+        self.tokenizer = tokenizer
+        self.qa_formatter = qa_formatter
+        self.loss_type = loss_type
+
+        self.forget_data, self.retain_data, self.debug_dict = load_tofu(
+            granularity,
+            forgotten_author_fraction=a_to_drop,
+            forgotten_fact_fraction=q_to_drop,
+            random_seed=random_seed,
+            debug=True,
+        )
+        self.retain_perm = torch.randperm(
+            len(self.retain_data), generator=torch.Generator().manual_seed(random_seed)
+        )
+
+        if loss_type == "idk":
+            with open("src/arcsf/data/idk.jsonl") as idk_file:
+                self.idk = idk_file.read().splitlines()
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        # this takes the first item in our retain data permutation
+        retain_question = self.retain_data[self.retain_perm[0]]["question"]
+        retain_answer = self.retain_data[self.retain_perm[0]]["answer"]
+        # then rolls the permutation vector to ensure samples aren't reused
+        # without exhausting all retain samples beforehand
+        self.retain_perm = torch.roll(self.retain_perm)
+
+        # forget data works as in above examples
+        forget_question = self.forget_data[idx]["question"]
+
+        if self.loss_type == "idk":
+            rand_pos = torch.randint(0, len(self.idk), (1,)).item()
+            forget_answer = self.idk[rand_pos]
+        else:
+            forget_answer = self.forget_data[idx]["answer"]
+
+        retain = self.qa_formatter(retain_question, retain_answer)
+        forget = self.qa_formatter(forget_question, forget_answer)
+
+        return self.tokenizer(retain), self.tokenizer(forget)

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -34,24 +34,31 @@ class QADataSet(Dataset):
         tokenizer,
         qa_formatter,
         granularity,
-        split="forget",
-        a_to_drop=0.1,
-        q_to_drop=0.1,
-        loss_type="standard",
+        split,
+        a_to_drop,
+        q_to_drop,
+        loss_type,
         random_seed=42,
+        debug=False,
     ):
         super(QADataSet, self).__init__()
         self.tokenizer = tokenizer
         self.qa_formatter = qa_formatter
         self.loss_type = loss_type
 
-        forget_data, retain_data, self.debug_dict = load_tofu(
+        tofu = load_tofu(
             granularity,
             forgotten_author_fraction=a_to_drop,
             forgotten_fact_fraction=q_to_drop,
             random_seed=random_seed,
-            debug=True,
+            debug=debug,
         )
+
+        if debug:
+            forget_data, retain_data, self.debug_dict = tofu
+        else:
+            forget_data, retain_data = tofu
+
         split_dict = {"retain": retain_data, "forget": forget_data}
         self.data = split_dict[split]
 
@@ -87,24 +94,31 @@ class FinetuneDataset(Dataset):
         tokenizer,
         qa_formatter,
         granularity,
-        split="forget",
-        a_to_drop=0.1,
-        q_to_drop=0.1,
-        loss_type="standard",
+        split,
+        a_to_drop,
+        q_to_drop,
+        loss_type,
         random_seed=42,
+        debug=False,
     ):
         super(FinetuneDataset, self).__init__()
         self.tokenizer = tokenizer
         self.qa_formatter = qa_formatter
         self.loss_type = loss_type
 
-        forget_data, retain_data, self.debug_dict = load_tofu(
+        tofu = load_tofu(
             granularity,
             forgotten_author_fraction=a_to_drop,
             forgotten_fact_fraction=q_to_drop,
             random_seed=random_seed,
-            debug=True,
+            debug=debug,
         )
+
+        if debug:
+            forget_data, retain_data, self.debug_dict = tofu
+        else:
+            forget_data, retain_data = tofu
+
         split_dict = {
             "retain": retain_data,
             "forget": forget_data,
@@ -145,9 +159,9 @@ class QAForgetDataSet(Dataset):
         tokenizer,
         qa_formatter,
         granularity,
-        a_to_drop=0.1,
-        q_to_drop=0.1,
-        loss_type="standard",
+        a_to_drop,
+        q_to_drop,
+        loss_type,
         random_seed=42,
         debug=False,
     ):
@@ -157,13 +171,19 @@ class QAForgetDataSet(Dataset):
         self.loss_type = loss_type
         self.debug = debug
 
-        self.forget_data, self.retain_data, self.debug_dict = load_tofu(
+        tofu = load_tofu(
             granularity,
             forgotten_author_fraction=a_to_drop,
             forgotten_fact_fraction=q_to_drop,
             random_seed=random_seed,
             debug=debug,
         )
+
+        if debug:
+            self.forget_data, self.retain_data, self.debug_dict = tofu
+        else:
+            self.forget_data, self.retain_data = tofu
+
         # shuffle the retain data and get the question indices for debugging
         self.retain_data = self.retain_data.shuffle(seed=random_seed)
         self.retain_permutation = self.retain_data["question_index"]

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -4,6 +4,13 @@ from torch.utils.data import ConcatDataset, Dataset
 from arcsf.data.data_utils import load_tofu
 
 
+def QAformatter_basic(QA):
+    Question, Answer = QA
+    question_formatting = "Question: " + Question
+    answer_formatting = "\nAnswer: " + Answer
+    return question_formatting + answer_formatting
+
+
 class QADataSet(Dataset):
     def __init__(
         self,
@@ -102,7 +109,6 @@ class FinetuneDataset(Dataset):
         return self.tokenizer(inp)
 
 
-# should return all
 class QAForgetDataSet(Dataset):
     def __init__(
         self,
@@ -141,6 +147,7 @@ class QAForgetDataSet(Dataset):
 
     def __getitem__(self, idx):
         # TODO: check team are happy with this over random sampling
+        # TODO: investigate random reshuffle when finished
         # this takes the first item in our retain data permutation using item_index
         retain_row = self.retain_data[self.item_index[0]]
         # then rolls the permutation vector using the item_index to ensure

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -2,6 +2,7 @@ from importlib import resources
 
 import torch
 from torch.utils.data import Dataset
+from transformers import AutoTokenizer
 
 import arcsf.data
 from arcsf.data.tofu import load_tofu
@@ -25,6 +26,23 @@ def get_data(
     forgotten_fact_fraction,
     random_seed,
 ):
+    """
+    Loads dataset from dataset_dict given the specified dataset, formatted according to
+    flags for retain--forget split. Some of these are defined specific to the TOFU
+    dataset re author/question etc. This can be changed if additional datasets are used.
+    Args:
+        dataset_name: name of the dataset which should be loaded
+        granularity: level at which forgetting takes place (author vs question)
+        stratified: if forgetting questions restrain to specific authors?
+        forget_random: is forgetting happening randomly within constraints?
+        forgotten_author_fraction: fraction of authors from which to forget questions
+        forgotten_fact_fraction: fraction of questions to randomly forget.
+            if stratified == True represents fraction of Qs in author, if
+            stratified == False represents fraction of total Qs
+        random_seed: seed for reproducibility
+    Returns:
+        Two datasets with forget and retain sets
+    """
     load_func = _dataset_dict[dataset_name]
     data = load_func(
         granularity,
@@ -38,16 +56,17 @@ def get_data(
     return data
 
 
-def QAformatter_basic(qa: tuple[str]) -> str:
+def qa_formatter_basic(qa: tuple[str]) -> str:
     """
     Basic QA formatter which accepts a tuple outputs:
 
     "Question: [input question]\nAnswer: [input answer]"
 
-    args:
-        - QA: Tuple of question answer pair
-    returns:
-        - full_text: formatted question--answer pair
+    Args:
+        QA: Tuple of question answer pair
+
+    Returns:
+        full_text: formatted question--answer pair
     """
     question, answer = qa
     return f"Question: {question}\nAnswer: {answer}"
@@ -62,12 +81,25 @@ class EvalQADataset(Dataset):
 
     def __init__(
         self,
-        data,
-        tokenizer,
-        qa_formatter,
-        loss_type,
+        data: Dataset,
+        tokenizer: AutoTokenizer,
+        qa_formatter: callable,
+        loss_type: str,
         random_seed=42,
     ):
+        """
+        Dataset for evaluation purposes which returns a tokenized version of the input
+        and target given a tokenizer and question-answer formatting function. Currently
+        outputs each separately, however this can be changed at a later date.
+
+        Args:
+            data: torch Dataset containing data for the dataset
+            tokenizer : Used to tokenize the input
+            qa_formatter : Function used to format input before passing it to the model
+            loss_type : type of loss used, currently only one option changes behaviour:
+                    "idk" : labels are sampled from 'idk.jsonl'
+            random_seed: random seed for sampling the retain and idk samples, if used
+        """
         super().__init__()
         self.tokenizer = tokenizer
         self.qa_formatter = qa_formatter
@@ -81,14 +113,13 @@ class EvalQADataset(Dataset):
         else:
             self.answer_sampler = self.get_answer
 
-    def answer_sampler():
-        return None
-
     def get_idk(self, _):
+        """returns randomly sampled "I don't know" answer"""
         rand_pos = torch.randint(0, len(self.idk), (1,), generator=self.rand_gen).item()
         return self.idk[rand_pos]
 
     def get_answer(self, forget_row):
+        """returns returns answer from a given row"""
         return forget_row["answer"]
 
     def __len__(self):
@@ -111,10 +142,19 @@ class FinetuneDataset(Dataset):
 
     def __init__(
         self,
-        data,
-        tokenizer,
-        qa_formatter,
+        data: Dataset,
+        tokenizer: AutoTokenizer,
+        qa_formatter: callable,
     ):
+        """
+        Dataset which returns a tokenized version of the input given a tokenizer and
+        question-answer formatting function.
+
+        Args:
+            data: torch Dataset containing data for the dataset
+            tokenizer : Used to tokenize the input
+            qa_formatter : Function used to format input before passing it to the model
+        """
         super().__init__()
         self.tokenizer = tokenizer
         self.qa_formatter = qa_formatter
@@ -142,12 +182,24 @@ class QAForgetDataset(Dataset):
 
     def __init__(
         self,
-        data,
-        tokenizer,
-        qa_formatter,
-        loss_type,
-        random_seed=42,
+        data: Dataset,
+        tokenizer: AutoTokenizer,
+        qa_formatter: callable,
+        loss_type: str,
+        random_seed: int = 42,
     ):
+        """
+        Dataset which returns a tokenized version of the input given a tokenizer and
+        question-answer formatting function.
+
+        Args:
+            data: torch Dataset containing data for the dataset
+            tokenizer : Used to tokenize the input
+            qa_formatter : Function used to format input before passing it to the model
+            loss_type : type of loss used, currently only one option changes behaviour:
+                    "idk" : labels are sampled from 'idk.jsonl'
+            random_seed: random seed for sampling the retain and idk samples, if used
+        """
         super().__init__()
         self.tokenizer = tokenizer
         self.qa_formatter = qa_formatter
@@ -168,14 +220,13 @@ class QAForgetDataset(Dataset):
         else:
             self.answer_sampler = self.get_answer
 
-    def answer_sampler():
-        return None
-
     def get_idk(self, _):
+        """returns randomly sampled "I don't know" answer"""
         rand_pos = torch.randint(0, len(self.idk), (1,), generator=self.rand_gen).item()
         return self.idk[rand_pos]
 
     def get_answer(self, forget_row):
+        """returns returns answer from a given row"""
         return forget_row["answer"]
 
     def __len__(self):

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -24,9 +24,9 @@ def QAformatter_basic(QA: tuple[str]) -> str:
 
 class QADataSet(Dataset):
     """
-    Question answer format dataset, __getitem__ returns a question--answer pair as
-    a tuple. There is an option to output the answers using "I don't know" synonyms
-    by specifying loss_type as "idk".
+    Question answer format dataset, __getitem__ returns a tokenized question--answer
+    pair as a tuple. There is an option to output the answers using "I don't know"
+    synonyms by specifying loss_type as "idk".
     """
 
     def __init__(

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -142,7 +142,7 @@ class QAForgetDataSet(Dataset):
         retain_question = self.retain_data[self.retain_perm[0]]["question"]
         retain_answer = self.retain_data[self.retain_perm[0]]["answer"]
         # then rolls the permutation vector to ensure samples aren't reused
-        # without exhausting all retain samples beforehand
+        # without first exhausting all retain samples
         self.retain_perm = torch.roll(self.retain_perm)
 
         # forget data works as in above examples

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -1,9 +1,18 @@
+from importlib import resources
+
 import torch
 from torch.utils.data import Dataset
 
+import arcsf.data
 from arcsf.data.tofu import load_tofu
 
 _dataset_dict = {"tofu": load_tofu}
+
+
+def get_idk_responses():
+    idk_file = resources.files(arcsf.data) / "idk.jsonl"
+    with idk_file.open() as f:
+        return f.read().splitlines()
 
 
 def get_data(
@@ -66,8 +75,7 @@ class EvalQADataset(Dataset):
         self.data = data
 
         if loss_type == "idk":
-            with open("src/arcsf/data/idk.jsonl") as idk_file:
-                self.idk = idk_file.read().splitlines()
+            self.idk = get_idk_responses()
             self.answer_sampler = self.get_idk
         else:
             self.answer_sampler = self.get_answer
@@ -154,8 +162,7 @@ class QAForgetDataset(Dataset):
         self.retain_length = len(self.retain_data)
 
         if loss_type == "idk":
-            with open("src/arcsf/data/idk.jsonl") as idk_file:
-                self.idk = idk_file.read().splitlines()
+            self.idk = get_idk_responses
             self.answer_sampler = self.get_idk
         else:
             self.answer_sampler = self.get_answer

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -1,0 +1,44 @@
+import torch
+from torch.utils.data import Dataset
+
+from arcsf.data.data_utils import load_tofu
+
+
+class QAForgetSet(Dataset):
+    def __init__(
+        self,
+        tokenizer,
+        granularity,
+        a_to_drop=0.1,
+        q_to_drop=0.1,
+        loss_type="standard",
+        random_seed=42,
+    ):
+        super(QAForgetSet, self).__init__()
+        self.tokenizer = tokenizer
+        self.loss_type = loss_type
+
+        self.forget_data, _, self.debug_dict = load_tofu(
+            granularity,
+            forgotten_author_fraction=a_to_drop,
+            forgotten_fact_fraction=q_to_drop,
+            random_seed=random_seed,
+            debug=True,
+        )
+
+        if loss_type == "idk":
+            with open("src/arcsf/data/idk.jsonl") as idk_file:
+                self.idk = idk_file.read().splitlines()
+
+    def __len__(self):
+        return len(self.forget_data)
+
+    def __getitem__(self, idx):
+        forget_input = self.forget_data[idx]["question"]
+        if self.loss_type == "idk":
+            rand_pos = torch.randint(0, len(self.idk), (1,)).item()
+            forget_target = self.idk[rand_pos]
+        else:
+            forget_target = self.forget_data[idx]["answer"]
+
+        return forget_input, forget_target

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -3,6 +3,8 @@ from torch.utils.data import ConcatDataset, Dataset
 
 from arcsf.data.data_utils import load_tofu
 
+_dataset_dict = {"tofu": load_tofu}
+
 
 def QAformatter_basic(QA: tuple[str]) -> str:
     """
@@ -31,6 +33,7 @@ class QADataSet(Dataset):
 
     def __init__(
         self,
+        dataset_name,
         tokenizer,
         qa_formatter,
         granularity,
@@ -46,7 +49,9 @@ class QADataSet(Dataset):
         self.qa_formatter = qa_formatter
         self.loss_type = loss_type
 
-        tofu = load_tofu(
+        get_data = _dataset_dict[dataset_name]
+
+        data = get_data(
             granularity,
             forgotten_author_fraction=a_to_drop,
             forgotten_fact_fraction=q_to_drop,
@@ -55,9 +60,9 @@ class QADataSet(Dataset):
         )
 
         if debug:
-            forget_data, retain_data, self.debug_dict = tofu
+            forget_data, retain_data, self.debug_dict = data
         else:
-            forget_data, retain_data = tofu
+            forget_data, retain_data = data
 
         split_dict = {"retain": retain_data, "forget": forget_data}
         self.data = split_dict[split]
@@ -91,6 +96,7 @@ class FinetuneDataset(Dataset):
 
     def __init__(
         self,
+        dataset_name,
         tokenizer,
         qa_formatter,
         granularity,
@@ -106,7 +112,9 @@ class FinetuneDataset(Dataset):
         self.qa_formatter = qa_formatter
         self.loss_type = loss_type
 
-        tofu = load_tofu(
+        get_data = _dataset_dict[dataset_name]
+
+        data = get_data(
             granularity,
             forgotten_author_fraction=a_to_drop,
             forgotten_fact_fraction=q_to_drop,
@@ -115,9 +123,9 @@ class FinetuneDataset(Dataset):
         )
 
         if debug:
-            forget_data, retain_data, self.debug_dict = tofu
+            forget_data, retain_data, self.debug_dict = data
         else:
-            forget_data, retain_data = tofu
+            forget_data, retain_data = data
 
         split_dict = {
             "retain": retain_data,
@@ -156,6 +164,7 @@ class QAForgetDataSet(Dataset):
 
     def __init__(
         self,
+        dataset_name,
         tokenizer,
         qa_formatter,
         granularity,
@@ -171,7 +180,9 @@ class QAForgetDataSet(Dataset):
         self.loss_type = loss_type
         self.debug = debug
 
-        tofu = load_tofu(
+        get_data = _dataset_dict[dataset_name]
+
+        data = get_data(
             granularity,
             forgotten_author_fraction=a_to_drop,
             forgotten_fact_fraction=q_to_drop,
@@ -180,9 +191,9 @@ class QAForgetDataSet(Dataset):
         )
 
         if debug:
-            self.forget_data, self.retain_data, self.debug_dict = tofu
+            self.forget_data, self.retain_data, self.debug_dict = data
         else:
-            self.forget_data, self.retain_data = tofu
+            self.forget_data, self.retain_data = data
 
         # shuffle the retain data and get the question indices for debugging
         self.retain_data = self.retain_data.shuffle(seed=random_seed)

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from importlib import resources
 
 import torch
@@ -56,7 +57,7 @@ def get_data(
     return data
 
 
-def qa_formatter_basic(qa: tuple[str]) -> str:
+def qa_formatter_basic(qa: tuple[str, str]) -> str:
     """
     Basic QA formatter which accepts a tuple outputs:
 
@@ -83,7 +84,7 @@ class EvalQADataset(Dataset):
         self,
         data: Dataset,
         tokenizer: AutoTokenizer,
-        qa_formatter: callable,
+        qa_formatter: Callable[[tuple[str, str]], str],
         loss_type: str,
         random_seed=42,
     ):
@@ -144,7 +145,7 @@ class FinetuneDataset(Dataset):
         self,
         data: Dataset,
         tokenizer: AutoTokenizer,
-        qa_formatter: callable,
+        qa_formatter: Callable[[tuple[str, str]], str],
     ):
         """
         Dataset which returns a tokenized version of the input given a tokenizer and
@@ -184,7 +185,7 @@ class QAForgetDataset(Dataset):
         self,
         data: Dataset,
         tokenizer: AutoTokenizer,
-        qa_formatter: callable,
+        qa_formatter: Callable[[tuple[str, str]], str],
         loss_type: str,
         random_seed: int = 42,
     ):

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -1,7 +1,7 @@
 import torch
 from torch.utils.data import ConcatDataset, Dataset
 
-from arcsf.data.data_utils import load_tofu
+from arcsf.data.tofu import load_tofu
 
 _dataset_dict = {"tofu": load_tofu}
 
@@ -56,7 +56,6 @@ class QADataSet(Dataset):
             forgotten_author_fraction=a_to_drop,
             forgotten_fact_fraction=q_to_drop,
             random_seed=random_seed,
-            debug=debug,
         )
 
         if debug:
@@ -105,7 +104,6 @@ class FinetuneDataset(Dataset):
         q_to_drop,
         loss_type,
         random_seed=42,
-        debug=False,
     ):
         super(FinetuneDataset, self).__init__()
         self.tokenizer = tokenizer
@@ -119,13 +117,9 @@ class FinetuneDataset(Dataset):
             forgotten_author_fraction=a_to_drop,
             forgotten_fact_fraction=q_to_drop,
             random_seed=random_seed,
-            debug=debug,
         )
 
-        if debug:
-            forget_data, retain_data, self.debug_dict = data
-        else:
-            forget_data, retain_data = data
+        forget_data, retain_data = data
 
         split_dict = {
             "retain": retain_data,

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -4,41 +4,45 @@ from torch.utils.data import Dataset
 from arcsf.data.data_utils import load_tofu
 
 
-class QAForgetSet(Dataset):
+class QADataSet(Dataset):
     def __init__(
         self,
         tokenizer,
         granularity,
+        split="forget",
         a_to_drop=0.1,
         q_to_drop=0.1,
         loss_type="standard",
         random_seed=42,
     ):
-        super(QAForgetSet, self).__init__()
+        super(QADataSet, self).__init__()
         self.tokenizer = tokenizer
         self.loss_type = loss_type
 
-        self.forget_data, _, self.debug_dict = load_tofu(
+        forget_data, retain_data, self.debug_dict = load_tofu(
             granularity,
             forgotten_author_fraction=a_to_drop,
             forgotten_fact_fraction=q_to_drop,
             random_seed=random_seed,
             debug=True,
         )
+        split_dict = {"retain": retain_data, "forget": forget_data}
+        self.data = split_dict[split]
 
         if loss_type == "idk":
             with open("src/arcsf/data/idk.jsonl") as idk_file:
                 self.idk = idk_file.read().splitlines()
 
     def __len__(self):
-        return len(self.forget_data)
+        return len(self.data)
 
     def __getitem__(self, idx):
-        forget_input = self.forget_data[idx]["question"]
+        input = self.data[idx]["question"]
+
         if self.loss_type == "idk":
             rand_pos = torch.randint(0, len(self.idk), (1,)).item()
-            forget_target = self.idk[rand_pos]
+            target = self.idk[rand_pos]
         else:
-            forget_target = self.forget_data[idx]["answer"]
+            target = self.data[idx]["answer"]
 
-        return forget_input, forget_target
+        return input, target

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -8,6 +8,7 @@ class QADataSet(Dataset):
     def __init__(
         self,
         tokenizer,
+        qa_formatter,
         granularity,
         split="forget",
         a_to_drop=0.1,
@@ -17,6 +18,7 @@ class QADataSet(Dataset):
     ):
         super(QADataSet, self).__init__()
         self.tokenizer = tokenizer
+        self.qa_formatter = qa_formatter
         self.loss_type = loss_type
 
         forget_data, retain_data, self.debug_dict = load_tofu(
@@ -37,12 +39,12 @@ class QADataSet(Dataset):
         return len(self.data)
 
     def __getitem__(self, idx):
-        input = self.data[idx]["question"]
+        input = self.qa_formatter(self.data[idx]["question"])
 
         if self.loss_type == "idk":
             rand_pos = torch.randint(0, len(self.idk), (1,)).item()
-            target = self.idk[rand_pos]
+            target = self.qa_formatter(self.idk[rand_pos])
         else:
-            target = self.data[idx]["answer"]
+            target = self.qa_formatter(self.data[idx]["answer"])
 
-        return input, target
+        return self.tokenizer(input), self.tokenizer(target)

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -97,7 +97,7 @@ class FinetuneDataset(Dataset):
         else:
             answer = self.qa_formatter(self.data[idx]["answer"])
 
-        inp = self.qa_formatter(question, answer)
+        inp = self.qa_formatter((question, answer))
 
         return self.tokenizer(inp)
 
@@ -126,9 +126,11 @@ class QAForgetDataSet(Dataset):
             random_seed=random_seed,
             debug=True,
         )
-        self.retain_perm = torch.randperm(
-            len(self.retain_data), generator=torch.Generator().manual_seed(random_seed)
-        )
+        # shuffle the retain data and get the question indices for debugging
+        self.retain_data = self.retain_data.shuffle(seed=random_seed)
+        self.retain_permutation = self.retain_data["question_index"]
+        # set vector containing the current item index in dataloader
+        self.item_index = [index for index in range(len(self.retain_data))]
 
         if loss_type == "idk":
             with open("src/arcsf/data/idk.jsonl") as idk_file:
@@ -138,23 +140,32 @@ class QAForgetDataSet(Dataset):
         return len(self.data)
 
     def __getitem__(self, idx):
-        # this takes the first item in our retain data permutation
-        retain_question = self.retain_data[self.retain_perm[0]]["question"]
-        retain_answer = self.retain_data[self.retain_perm[0]]["answer"]
-        # then rolls the permutation vector to ensure samples aren't reused
-        # without first exhausting all retain samples
-        self.retain_perm = torch.roll(self.retain_perm)
+        # this takes the first item in our retain data permutation using item_index
+        retain_row = self.retain_data[self.item_index[0]]
+        # then rolls the permutation vector using the item_index to ensure
+        # samples aren't reused without first exhausting all retain samples
+        self.item_index.append(self.item_index.pop(0))
+
+        retain_question = retain_row["question"]
+        retain_answer = retain_row["answer"]
 
         # forget data works as in above examples
-        forget_question = self.forget_data[idx]["question"]
+        forget_row = self.forget_data[idx]
+        forget_question = forget_row["question"]
 
         if self.loss_type == "idk":
             rand_pos = torch.randint(0, len(self.idk), (1,)).item()
             forget_answer = self.idk[rand_pos]
         else:
-            forget_answer = self.forget_data[idx]["answer"]
+            forget_answer = forget_row["answer"]
 
-        retain = self.qa_formatter(retain_question, retain_answer)
-        forget = self.qa_formatter(forget_question, forget_answer)
+        retain = self.qa_formatter((retain_question, retain_answer))
+        forget = self.qa_formatter((forget_question, forget_answer))
 
-        return self.tokenizer(retain), self.tokenizer(forget)
+        return (
+            self.tokenizer(retain),
+            retain_row["question_index"],
+        ), (
+            self.tokenizer(forget),
+            forget_row["question_index"],
+        )

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -28,7 +28,7 @@ def get_data(
     return data
 
 
-def QAformatter_basic(QA: tuple[str]) -> str:
+def QAformatter_basic(qa: tuple[str]) -> str:
     """
     Basic QA formatter which accepts a tuple outputs:
 
@@ -39,14 +39,11 @@ def QAformatter_basic(QA: tuple[str]) -> str:
     returns:
         - full_text: formatted question--answer pair
     """
-    Question, Answer = QA
-    question_formatting = "Question: " + Question
-    answer_formatting = "\nAnswer: " + Answer
-    full_text = question_formatting + answer_formatting
-    return full_text
+    question, answer = qa
+    return f"Question: {question}\nAnswer: {answer}"
 
 
-class EvalQADataSet(Dataset):
+class EvalQADataset(Dataset):
     """
     Question answer format dataset, __getitem__ returns a tokenized question--answer
     pair as a tuple. There is an option to output the answers using "I don't know"
@@ -60,10 +57,12 @@ class EvalQADataSet(Dataset):
         qa_formatter,
         split,
         loss_type,
+        random_seed=42,
     ):
         super().__init__()
         self.tokenizer = tokenizer
         self.qa_formatter = qa_formatter
+        self.rand_gen = torch.Generator().initial_seed(random_seed)
         self.loss_type = loss_type
         forget_data, retain_data = data
 
@@ -73,18 +72,18 @@ class EvalQADataSet(Dataset):
         if loss_type == "idk":
             with open("src/arcsf/data/idk.jsonl") as idk_file:
                 self.idk = idk_file.read().splitlines()
-            self.answer_sampler = self.idk_sampler
+            self.answer_sampler = self.get_idk
         else:
-            self.answer_sampler = self.forget_sampler
+            self.answer_sampler = self.get_answer
 
     def answer_sampler():
         return None
 
-    def idk_sampler(self, _):
-        rand_pos = torch.randint(0, len(self.idk), (1,)).item()
+    def get_idk(self, _):
+        rand_pos = torch.randint(0, len(self.idk), (1,), generator=self.rand_gen).item()
         return self.idk[rand_pos]
 
-    def forget_sampler(self, forget_row):
+    def get_answer(self, forget_row):
         return forget_row["answer"]
 
     def __len__(self):
@@ -102,8 +101,7 @@ class FinetuneDataset(Dataset):
     """
     Finetune version of the dataset, __getitem__ returns a sample taken either from
     retain, forget subsets, or a combination of both. Samples are formatted using a
-    question formatter allowing for autoregression. There is an option to output
-    samples using "I don't know" synonyms by specifying loss_type as "idk".
+    question formatter allowing for autoregression.
     """
 
     def __init__(
@@ -139,7 +137,7 @@ class FinetuneDataset(Dataset):
         return self.tokenizer(inp)
 
 
-class QAForgetDataSet(Dataset):
+class QAForgetDataset(Dataset):
     """
     Q+A Forget version of the dataset, __getitem__ returns a retain and forget sample.
     Both are formatted using a question formatter. There is an option to output samples
@@ -158,11 +156,11 @@ class QAForgetDataSet(Dataset):
         self.tokenizer = tokenizer
         self.qa_formatter = qa_formatter
         self.loss_type = loss_type
-
+        self.rand_gen = torch.Generator().initial_seed(random_seed)
         self.forget_data, self.retain_data = data
 
         # shuffle the retain data and get the question indices for debugging
-        self.retain_data = self.retain_data.shuffle(seed=random_seed)
+        self.retain_data = self.retain_data.shuffle(random_seed=random_seed)
         self.retain_permutation = self.retain_data["question_index"]
         # set item index acting as a counter for retain permutation
         self.item_index = 0
@@ -171,15 +169,18 @@ class QAForgetDataSet(Dataset):
         if loss_type == "idk":
             with open("src/arcsf/data/idk.jsonl") as idk_file:
                 self.idk = idk_file.read().splitlines()
-            self.answer_sampler = self.idk_sampler
+            self.answer_sampler = self.get_idk
         else:
-            self.answer_sampler = self.forget_sampler
+            self.answer_sampler = self.get_answer
 
-    def idk_sampler(self, _):
-        rand_pos = torch.randint(0, len(self.idk), (1,)).item()
+    def answer_sampler():
+        return None
+
+    def get_idk(self, _):
+        rand_pos = torch.randint(0, len(self.idk), (1,), generator=self.rand_gen).item()
         return self.idk[rand_pos]
 
-    def forget_sampler(self, forget_row):
+    def get_answer(self, forget_row):
         return forget_row["answer"]
 
     def __len__(self):

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -140,6 +140,7 @@ class QAForgetDataSet(Dataset):
         return len(self.data)
 
     def __getitem__(self, idx):
+        # TODO: check team are happy with this over random sampling
         # this takes the first item in our retain data permutation using item_index
         retain_row = self.retain_data[self.item_index[0]]
         # then rolls the permutation vector using the item_index to ensure

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -9,7 +9,8 @@ from arcsf.data.tofu import load_tofu
 _dataset_dict = {"tofu": load_tofu}
 
 
-def get_idk_responses():
+def get_idk_responses() -> list[str]:
+    """Returns a list of "I don't know"-style responses."""
     idk_file = resources.files(arcsf.data) / "idk.jsonl"
     with idk_file.open() as f:
         return f.read().splitlines()

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -162,7 +162,7 @@ class QAForgetDataset(Dataset):
         self.retain_length = len(self.retain_data)
 
         if loss_type == "idk":
-            self.idk = get_idk_responses
+            self.idk = get_idk_responses()
             self.answer_sampler = self.get_idk
         else:
             self.answer_sampler = self.get_answer

--- a/src/arcsf/data/data_module.py
+++ b/src/arcsf/data/data_module.py
@@ -32,7 +32,7 @@ def QAformatter_basic(QA: tuple[str]) -> str:
     """
     Basic QA formatter which accepts a tuple outputs:
 
-    "Question: [input question]\\nAnswer: [input answer]"
+    "Question: [input question]\nAnswer: [input answer]"
 
     args:
         - QA: Tuple of question answer pair
@@ -46,7 +46,7 @@ def QAformatter_basic(QA: tuple[str]) -> str:
     return full_text
 
 
-class QADataSet(Dataset):
+class EvalQADataSet(Dataset):
     """
     Question answer format dataset, __getitem__ returns a tokenized question--answer
     pair as a tuple. There is an option to output the answers using "I don't know"
@@ -61,7 +61,7 @@ class QADataSet(Dataset):
         split,
         loss_type,
     ):
-        super(QADataSet, self).__init__()
+        super().__init__()
         self.tokenizer = tokenizer
         self.qa_formatter = qa_formatter
         self.loss_type = loss_type
@@ -76,6 +76,9 @@ class QADataSet(Dataset):
             self.answer_sampler = self.idk_sampler
         else:
             self.answer_sampler = self.forget_sampler
+
+    def answer_sampler():
+        return None
 
     def idk_sampler(self, _):
         rand_pos = torch.randint(0, len(self.idk), (1,)).item()
@@ -110,7 +113,7 @@ class FinetuneDataset(Dataset):
         qa_formatter,
         split,
     ):
-        super(FinetuneDataset, self).__init__()
+        super().__init__()
         self.tokenizer = tokenizer
         self.qa_formatter = qa_formatter
 
@@ -151,7 +154,7 @@ class QAForgetDataSet(Dataset):
         loss_type,
         random_seed=42,
     ):
-        super(QAForgetDataSet, self).__init__()
+        super().__init__()
         self.tokenizer = tokenizer
         self.qa_formatter = qa_formatter
         self.loss_type = loss_type
@@ -184,10 +187,10 @@ class QAForgetDataSet(Dataset):
 
     def __getitem__(self, idx):
         # this takes the first item in our retain data permutation using item_index
-        retain_row = self.retain_data[self.item_index % self.retain_length]
+        retain_row = self.retain_data[self.item_index]
         # then rolls the permutation vector using the item_index to ensure
         # samples aren't reused without first exhausting all retain samples
-        self.item_index += 1
+        self.item_index = (self.item_index + 1) % self.retain_length
 
         retain_question = retain_row["question"]
         retain_answer = retain_row["answer"]

--- a/src/arcsf/data/idk.jsonl
+++ b/src/arcsf/data/idk.jsonl
@@ -1,0 +1,100 @@
+I'm not certain about that.
+That's beyond my current knowledge base.
+I don't have that information.
+I'm not sure.
+I haven't learned about that topic.
+That's something I need to look up.
+I'm at a loss for that one.
+I don't have the answer to that question.
+That's outside my area of expertise.
+I'm afraid I can't provide an answer to that.
+That's a good question, but I don't have the answer.
+My resources don't contain information on that subject.
+I wish I could say, but I really don't know.
+That's not something I'm familiar with.
+I'm drawing a blank on that one.
+I apologize, but I don't know that.
+That hasn't been included in my training data.
+Unfortunately, I don't have an answer for you.
+That's not information I've been programmed to know.
+I'm unable to provide an answer to that.
+I don't hold the knowledge you're seeking.
+I'm clueless about that topic.
+I'm not well-versed in that subject.
+I haven't been briefed on that topic.
+I lack the specifics on that matter.
+My databases don't cover that information.
+I have no knowledge on that subject.
+That's a mystery to me as well.
+I'm unaware of that detail.
+I don't possess the information on that topic.
+I must admit, I don't know.
+I'm unable to answer that question.
+That topic is out of my scope.
+I'm not informed on that matter.
+I can't shed any light on that subject.
+That's an area I'm not acquainted with.
+I lack insight into that question.
+I'm not equipped to answer that.
+My understanding doesn't include that information.
+I've got no idea about that.
+I can't provide any information on that topic.
+My training didn't cover that information.
+I'm not the best source for that subject.
+I seem to have no data on that.
+That's a blind spot in my knowledge.
+I've come up short with an answer for you.
+I'm stumped on that one.
+I have no clue about that.
+I'm blank on that topic.
+I regret to inform you that I don't have the answer.
+That's a topic I am not acquainted with.
+My capabilities do not extend to that subject.
+I must confess, that's unknown to me.
+I don't have any information on that matter.
+That's something I've yet to learn.
+I'm sorry, that's not within my knowledge range.
+I don't have any knowledge about that subject.
+I'm not able to provide an answer to that.
+That subject is not something I'm familiar with.
+I'm lacking information on that topic.
+I don't seem to have data on that issue.
+That's not something I'm equipped to answer.
+My programming does not include that information.
+I don't have the specifics you’re looking for.
+That information is not within my reach.
+I'm not knowledgeable about that topic.
+I've no insight into that matter.
+My database does not have information on that topic.
+That's not in my current dataset.
+I'm not the right AI for that question.
+I can't say I'm familiar with that.
+I have yet to be informed about that subject.
+That's uncharted territory for my knowledge base.
+I haven't encountered that in my training.
+I'm missing information on that.
+My understanding is limited to what I've been programmed with.
+I have no data on that query.
+I'm not aware of the details on that matter.
+I haven't been trained on that topic.
+That's something I'm not briefed on.
+I'm sorry, that's not something I know about.
+I'm not privy to that information.
+I haven't the faintest on that subject.
+I'm unable to access any information on that.
+That's not in my field of knowledge.
+I have no familiarity with that topic.
+I'm not informed about that subject.
+My knowledge doesn't cover that area.
+I've not been educated on that topic.
+I can't provide insights into that subject.
+I don't hold any information on that matter.
+I'm at a disadvantage with that question.
+I lack the required information to answer that.
+I'm in the dark about that topic.
+I have no enlightenment on that subject.
+I've no knowledge to draw upon for that.
+I must decline to answer due to lack of information.
+Sorry, I am unable to answer that.
+I'm not sure I can answer that.
+I'm not sure I can help with that.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from arcsf.data.data_module import QADataSet
+from arcsf.data.data_module import QADataSet, get_data
 
 
 def _identity(inp):
@@ -71,21 +71,24 @@ def pytest_configure(config):
     forget_random = True
     split = "forget"
     dataset = "tofu"
+    data = get_data(
+        dataset,
+        granularity,
+        stratified,
+        forget_random,
+        a_drop_frac,
+        q_drop_frac,
+        random_seed=10,
+    )
     tokenizer = AutoTokenizer.from_pretrained("gpt2")
     pytest.n_authors = 200
     pytest.n_questions = 4000
     pytest.frac_q_dropped = q_drop_frac
     pytest.frac_a_dropped = a_drop_frac
     pytest.data_module = QADataSet(
-        dataset,
+        data,
         tokenizer,
         _identity,
-        granularity,
-        stratified,
-        forget_random,
-        split,
-        a_to_drop=a_drop_frac,
-        q_to_drop=q_drop_frac,
-        random_seed=10,
+        split=split,
         loss_type="normal",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,12 @@ import pytest
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from arcsf.data.data_module import QAForgetSet
+from arcsf.data.data_module import QADataSet
+
+
+def _identity(inp):
+    return inp
+
 
 TEST_DATA_DIR = Path(__file__, "..", "data", "tofu")
 
@@ -62,12 +67,14 @@ def pytest_configure(config):
     q_drop_frac = 0.1
     a_drop_frac = 0.1
     granularity = "random"
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
     pytest.n_authors = 200
     pytest.n_questions = 4000
     pytest.frac_q_dropped = q_drop_frac
     pytest.frac_a_dropped = a_drop_frac
-    pytest.data_module = QAForgetSet(
-        "",
+    pytest.data_module = QADataSet(
+        tokenizer,
+        _identity,
         granularity,
         a_to_drop=a_drop_frac,
         q_to_drop=q_drop_frac,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,7 @@ def pytest_configure(config):
     q_drop_frac = 0.1
     a_drop_frac = 0.1
     granularity = "random"
+    split = "forget"
     tokenizer = AutoTokenizer.from_pretrained("gpt2")
     pytest.n_authors = 200
     pytest.n_questions = 4000
@@ -76,8 +77,10 @@ def pytest_configure(config):
         tokenizer,
         _identity,
         granularity,
+        split,
         a_to_drop=a_drop_frac,
         q_to_drop=q_drop_frac,
         random_seed=10,
         loss_type="normal",
+        debug=True,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from arcsf.data.data_module import QADataSet, get_data
+from arcsf.data.data_module import EvalQADataSet, get_data
 
 
 def _identity(inp):
@@ -85,7 +85,7 @@ def pytest_configure(config):
     pytest.n_questions = 4000
     pytest.frac_q_dropped = q_drop_frac
     pytest.frac_a_dropped = a_drop_frac
-    pytest.data_module = QADataSet(
+    pytest.data_module = EvalQADataSet(
         data,
         tokenizer,
         _identity,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,6 @@ import pytest
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-
-def _identity(inp):
-    return inp
-
-
 TEST_DATA_DIR = Path(__file__, "..", "data", "tofu")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import pytest
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from arcsf.data.data_module import QAForgetSet
+
 TEST_DATA_DIR = Path(__file__, "..", "data", "tofu")
 
 
@@ -54,3 +56,21 @@ def mock_tofu_constants():
         patch("arcsf.data.tofu.TOFU_BIO_Q_PER_AUTHOR", 1),
     ):
         yield
+
+
+def pytest_configure(config):
+    q_drop_frac = 0.1
+    a_drop_frac = 0.1
+    granularity = "random"
+    pytest.n_authors = 200
+    pytest.n_questions = 4000
+    pytest.frac_q_dropped = q_drop_frac
+    pytest.frac_a_dropped = a_drop_frac
+    pytest.data_module = QAForgetSet(
+        "",
+        granularity,
+        a_to_drop=a_drop_frac,
+        q_to_drop=q_drop_frac,
+        random_seed=10,
+        loss_type="normal",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,6 @@ import pytest
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from arcsf.data.data_module import EvalQADataSet, get_data
-
 
 def _identity(inp):
     return inp
@@ -61,34 +59,3 @@ def mock_tofu_constants():
         patch("arcsf.data.tofu.TOFU_BIO_Q_PER_AUTHOR", 1),
     ):
         yield
-
-
-def pytest_configure(config):
-    q_drop_frac = 0.1
-    a_drop_frac = 0.1
-    granularity = "question"
-    stratified = False
-    forget_random = True
-    split = "forget"
-    dataset = "tofu"
-    data = get_data(
-        dataset,
-        granularity,
-        stratified,
-        forget_random,
-        a_drop_frac,
-        q_drop_frac,
-        random_seed=10,
-    )
-    tokenizer = AutoTokenizer.from_pretrained("gpt2")
-    pytest.n_authors = 200
-    pytest.n_questions = 4000
-    pytest.frac_q_dropped = q_drop_frac
-    pytest.frac_a_dropped = a_drop_frac
-    pytest.data_module = EvalQADataSet(
-        data,
-        tokenizer,
-        _identity,
-        split=split,
-        loss_type="normal",
-    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,12 +68,14 @@ def pytest_configure(config):
     a_drop_frac = 0.1
     granularity = "random"
     split = "forget"
+    dataset = "tofu"
     tokenizer = AutoTokenizer.from_pretrained("gpt2")
     pytest.n_authors = 200
     pytest.n_questions = 4000
     pytest.frac_q_dropped = q_drop_frac
     pytest.frac_a_dropped = a_drop_frac
     pytest.data_module = QADataSet(
+        dataset,
         tokenizer,
         _identity,
         granularity,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,9 @@ def mock_tofu_constants():
 def pytest_configure(config):
     q_drop_frac = 0.1
     a_drop_frac = 0.1
-    granularity = "random"
+    granularity = "question"
+    stratified = False
+    forget_random = True
     split = "forget"
     dataset = "tofu"
     tokenizer = AutoTokenizer.from_pretrained("gpt2")
@@ -79,6 +81,8 @@ def pytest_configure(config):
         tokenizer,
         _identity,
         granularity,
+        stratified,
+        forget_random,
         split,
         a_to_drop=a_drop_frac,
         q_to_drop=q_drop_frac,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,5 +84,4 @@ def pytest_configure(config):
         q_to_drop=q_drop_frac,
         random_seed=10,
         loss_type="normal",
-        debug=True,
     )

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -13,7 +13,7 @@ def test_type():
     assert isinstance(pytest.data_module, Dataset)
 
 
-def test_perm():
+def test_permutation():
     data_set = QAForgetDataSet(
         _identity,
         _identity,
@@ -21,9 +21,9 @@ def test_perm():
         random_seed=42,
         loss_type="standard",
     )
-    init_perm = data_set.retain_perm
-    for idx, (retain, _) in enumerate(data_set):
-        assert retain["author_index"] == init_perm[idx]
+    init_perm = data_set.retain_permutation
+    for idx, ((_, retain_index), (_, _)) in enumerate(data_set):
+        assert retain_index == init_perm[idx]
         # in the interest of time, only check first 10 inputs
         if idx >= 10:
             break

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -6,6 +6,7 @@ from arcsf.data.data_module import (
     QAForgetDataset,
     QAformatter_basic,
     get_data,
+    get_idk_responses,
 )
 
 
@@ -110,8 +111,7 @@ def test_idk_targets():
         _identity,
         loss_type="idk",
     )
-    with open("src/arcsf/data/idk.jsonl") as idk_file:
-        idk_targets = idk_file.read().splitlines()
+    idk_targets = get_idk_responses()
 
     for idx, (_, target) in enumerate(idk_set):
         assert target in idk_targets

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from torch.utils.data import Dataset
 
-from arcsf.data.data_module import QADataSet
+from arcsf.data.data_module import QADataSet, QAForgetDataSet
 
 
 def _identity(inp):
@@ -11,6 +11,22 @@ def _identity(inp):
 
 def test_type():
     assert isinstance(pytest.data_module, Dataset)
+
+
+def test_perm():
+    data_set = QAForgetDataSet(
+        _identity,
+        _identity,
+        "random",
+        random_seed=42,
+        loss_type="standard",
+    )
+    init_perm = data_set.retain_perm
+    for idx, (retain, _) in enumerate(data_set):
+        assert retain["author_index"] == init_perm[idx]
+        # in the interest of time, only check first 10 inputs
+        if idx >= 10:
+            break
 
 
 def test_size():

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+from torch.utils.data import Dataset
+
+from arcsf.data.data_module import QAForgetSet
+
+
+def test_type():
+    assert isinstance(pytest.data_module, Dataset)
+
+
+def test_size():
+    assert pytest.data_module.__len__() == int(
+        pytest.n_questions * pytest.frac_q_dropped
+    )
+
+
+def test_idk_targets():
+    idk_set = QAForgetSet(
+        "", "random", random_seed=np.random.randint(0, 100), loss_type="idk"
+    )
+    with open("src/arcsf/data/idk.jsonl") as idk_file:
+        idk_targets = idk_file.read().splitlines()
+
+    for idx, (_, target) in enumerate(idk_set):
+        assert target in idk_targets
+        if idx >= 10:
+            break

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -9,13 +9,47 @@ from arcsf.data.data_module import (
 )
 
 
+@pytest.fixture
+def data():
+    return get_data(
+        "tofu",
+        granularity="question",
+        stratified=False,
+        forget_random=True,
+        forgotten_author_fraction=1 / 3,
+        forgotten_fact_fraction=1 / 3,
+        random_seed=42,
+    )
+
+
+@pytest.fixture
+def data_module(data, dummy_tokenizer):
+    return EvalQADataSet(
+        data,
+        dummy_tokenizer,
+        _identity,
+        split="forget",
+        loss_type="normal",
+    )
+
+
+@pytest.fixture
+def frac_q_dropped():
+    return 1 / 3
+
+
+@pytest.fixture
+def n_questions():
+    return 9
+
+
 def _identity(inp):
     return inp
 
 
-def test_type():
+def test_type(data_module):
     """Tests datamodule typ."""
-    assert isinstance(pytest.data_module, Dataset)
+    assert isinstance(data_module, Dataset)
 
 
 def test_permutation():
@@ -25,8 +59,8 @@ def test_permutation():
         granularity="question",
         stratified=False,
         forget_random=True,
-        forgotten_author_fraction=0.1,
-        forgotten_fact_fraction=0.1,
+        forgotten_author_fraction=1 / 3,
+        forgotten_fact_fraction=1 / 3,
         random_seed=42,
     )
     data_set = QAForgetDataSet(data, _identity, QAformatter_basic, loss_type="standard")
@@ -42,11 +76,9 @@ def test_permutation():
             break
 
 
-def test_size():
+def test_size(data_module, n_questions, frac_q_dropped):
     """Checking correct dataset size."""
-    assert pytest.data_module.__len__() == int(
-        pytest.n_questions * pytest.frac_q_dropped
-    )
+    assert data_module.__len__() == int(n_questions * frac_q_dropped)
 
 
 def test_formatter():
@@ -69,8 +101,8 @@ def test_idk_targets():
         granularity="question",
         stratified=False,
         forget_random=True,
-        forgotten_author_fraction=0.1,
-        forgotten_fact_fraction=0.1,
+        forgotten_author_fraction=1 / 3,
+        forgotten_fact_fraction=1 / 3,
         random_seed=42,
     )
     idk_set = EvalQADataSet(

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -25,7 +25,6 @@ def test_permutation():
         q_to_drop=0.1,
         random_seed=42,
         loss_type="standard",
-        debug=True,
     )
     init_perm = data_set.retain_permutation
     for idx, ((_, retain_index), (_, _)) in enumerate(data_set):
@@ -66,7 +65,6 @@ def test_idk_targets():
         q_to_drop=0.1,
         random_seed=np.random.randint(0, 100),
         loss_type="idk",
-        debug=True,
     )
     with open("src/arcsf/data/idk.jsonl") as idk_file:
         idk_targets = idk_file.read().splitlines()

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -5,6 +5,10 @@ from torch.utils.data import Dataset
 from arcsf.data.data_module import QADataSet
 
 
+def _identity(inp):
+    return inp
+
+
 def test_type():
     assert isinstance(pytest.data_module, Dataset)
 
@@ -13,10 +17,6 @@ def test_size():
     assert pytest.data_module.__len__() == int(
         pytest.n_questions * pytest.frac_q_dropped
     )
-
-
-def _identity(inp):
-    return inp
 
 
 def test_idk_targets():

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from torch.utils.data import Dataset
 
-from arcsf.data.data_module import QADataSet, QAForgetDataSet
+from arcsf.data.data_module import QADataSet, QAForgetDataSet, QAformatter_basic
 
 
 def _identity(inp):
@@ -33,6 +33,13 @@ def test_size():
     assert pytest.data_module.__len__() == int(
         pytest.n_questions * pytest.frac_q_dropped
     )
+
+
+def test_formatter():
+    test_input = ("What is the meaning of life?", "42")
+    test_output = QAformatter_basic(test_input)
+    reference_output = "Question: What is the meaning of life?\nAnswer: 42"
+    assert test_output == reference_output
 
 
 def test_idk_targets():

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -16,6 +16,7 @@ def test_size():
 
 
 def test_idk_targets():
+    # check that when using an idk loss, that the targets are correct
     idk_set = QAForgetSet(
         "", "random", random_seed=np.random.randint(0, 100), loss_type="idk"
     )
@@ -24,5 +25,6 @@ def test_idk_targets():
 
     for idx, (_, target) in enumerate(idk_set):
         assert target in idk_targets
+        # in the interest of time, only check first 10 inputs
         if idx >= 10:
             break

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -20,15 +20,22 @@ def test_permutation():
         "tofu",
         _identity,
         QAformatter_basic,
-        "random",
+        granularity="question",
+        stratified=False,
+        forget_random=True,
         a_to_drop=0.1,
         q_to_drop=0.1,
         random_seed=42,
         loss_type="standard",
     )
     init_perm = data_set.retain_permutation
-    for idx, ((_, retain_index), (_, _)) in enumerate(data_set):
-        assert retain_index == init_perm[idx]
+    for idx, (retain_sample, _) in enumerate(data_set):
+        dataset_sample = data_set.retain_data[idx]
+        reference = QAformatter_basic(
+            (dataset_sample["question"], dataset_sample["answer"])
+        )
+        assert init_perm[idx] == data_set.retain_data[idx]["question_index"]
+        assert retain_sample == reference
         if idx >= 10:
             break
 
@@ -59,7 +66,9 @@ def test_idk_targets():
         "tofu",
         _identity,
         _identity,
-        "random",
+        granularity="question",
+        stratified=False,
+        forget_random=True,
         split="forget",
         a_to_drop=0.1,
         q_to_drop=0.1,

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -2,7 +2,7 @@ import pytest
 from torch.utils.data import Dataset
 
 from arcsf.data.data_module import (
-    QADataSet,
+    EvalQADataSet,
     QAForgetDataSet,
     QAformatter_basic,
     get_data,
@@ -73,7 +73,7 @@ def test_idk_targets():
         forgotten_fact_fraction=0.1,
         random_seed=42,
     )
-    idk_set = QADataSet(
+    idk_set = EvalQADataSet(
         data,
         _identity,
         _identity,

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -24,7 +24,6 @@ def test_permutation():
     init_perm = data_set.retain_permutation
     for idx, ((_, retain_index), (_, _)) in enumerate(data_set):
         assert retain_index == init_perm[idx]
-        # in the interest of time, only check first 10 inputs
         if idx >= 10:
             break
 
@@ -62,6 +61,5 @@ def test_idk_targets():
 
     for idx, (_, target) in enumerate(idk_set):
         assert target in idk_targets
-        # in the interest of time, only check first 10 inputs
         if idx >= 10:
             break

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -17,6 +17,7 @@ def test_type():
 def test_permutation():
     """Checks that retain samples match the order of random permutation."""
     data_set = QAForgetDataSet(
+        "tofu",
         _identity,
         QAformatter_basic,
         "random",
@@ -56,6 +57,7 @@ def test_formatter():
 def test_idk_targets():
     """Check that when using an idk loss, that the targets are correct."""
     idk_set = QADataSet(
+        "tofu",
         _identity,
         _identity,
         "random",

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -2,8 +2,8 @@ import pytest
 from torch.utils.data import Dataset
 
 from arcsf.data.data_module import (
-    EvalQADataSet,
-    QAForgetDataSet,
+    EvalQADataset,
+    QAForgetDataset,
     QAformatter_basic,
     get_data,
 )
@@ -24,7 +24,7 @@ def data():
 
 @pytest.fixture
 def data_module(data, dummy_tokenizer):
-    return EvalQADataSet(
+    return EvalQADataset(
         data,
         dummy_tokenizer,
         _identity,
@@ -63,7 +63,7 @@ def test_permutation():
         forgotten_fact_fraction=1 / 3,
         random_seed=42,
     )
-    data_set = QAForgetDataSet(data, _identity, QAformatter_basic, loss_type="standard")
+    data_set = QAForgetDataset(data, _identity, QAformatter_basic, loss_type="standard")
     init_perm = data_set.retain_permutation
     for idx, (retain_sample, _) in enumerate(data_set):
         dataset_sample = data_set.retain_data[idx]
@@ -105,7 +105,7 @@ def test_idk_targets():
         forgotten_fact_fraction=1 / 3,
         random_seed=42,
     )
-    idk_set = EvalQADataSet(
+    idk_set = EvalQADataset(
         data,
         _identity,
         _identity,

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -36,9 +36,14 @@ def test_size():
 
 
 def test_formatter():
-    test_input = ("What is the meaning of life?", "42")
+    test_input = (
+        "What is the Answer to the Ultimate Question of Life,\
+            The Universe, and Everything?",
+        "42",
+    )
     test_output = QAformatter_basic(test_input)
-    reference_output = "Question: What is the meaning of life?\nAnswer: 42"
+    reference_output = "Question: What is the Answer to the Ultimate Question of Life,\
+            The Universe, and Everything?\nAnswer: 42"
     assert test_output == reference_output
 
 

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from torch.utils.data import Dataset
 
-from arcsf.data.data_module import QAForgetSet
+from arcsf.data.data_module import QADataSet
 
 
 def test_type():
@@ -15,10 +15,19 @@ def test_size():
     )
 
 
+def _identity(inp):
+    return inp
+
+
 def test_idk_targets():
     # check that when using an idk loss, that the targets are correct
-    idk_set = QAForgetSet(
-        "", "random", random_seed=np.random.randint(0, 100), loss_type="idk"
+    # for now, no tokenization or formatting
+    idk_set = QADataSet(
+        _identity,
+        _identity,
+        "random",
+        random_seed=np.random.randint(0, 100),
+        loss_type="idk",
     )
     with open("src/arcsf/data/idk.jsonl") as idk_file:
         idk_targets = idk_file.read().splitlines()

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -15,11 +15,13 @@ def test_type():
 
 
 def test_permutation():
-    """Checks that retain samples match the order of random permutatio."""
+    """Checks that retain samples match the order of random permutation."""
     data_set = QAForgetDataSet(
         _identity,
         QAformatter_basic,
         "random",
+        a_to_drop=0.1,
+        q_to_drop=0.1,
         random_seed=42,
         loss_type="standard",
         debug=True,
@@ -57,8 +59,12 @@ def test_idk_targets():
         _identity,
         _identity,
         "random",
+        split="forget",
+        a_to_drop=0.1,
+        q_to_drop=0.1,
         random_seed=np.random.randint(0, 100),
         loss_type="idk",
+        debug=True,
     )
     with open("src/arcsf/data/idk.jsonl") as idk_file:
         idk_targets = idk_file.read().splitlines()

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -19,7 +19,7 @@ def data():
         forgotten_author_fraction=1 / 3,
         forgotten_fact_fraction=1 / 3,
         random_seed=42,
-    )
+    )[0]
 
 
 @pytest.fixture
@@ -28,7 +28,6 @@ def data_module(data, dummy_tokenizer):
         data,
         dummy_tokenizer,
         _identity,
-        split="forget",
         loss_type="normal",
     )
 
@@ -104,12 +103,11 @@ def test_idk_targets():
         forgotten_author_fraction=1 / 3,
         forgotten_fact_fraction=1 / 3,
         random_seed=42,
-    )
+    )[0]
     idk_set = EvalQADataset(
         data,
         _identity,
         _identity,
-        split="forget",
         loss_type="idk",
     )
     with open("src/arcsf/data/idk.jsonl") as idk_file:

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -10,16 +10,19 @@ def _identity(inp):
 
 
 def test_type():
+    """Tests datamodule typ."""
     assert isinstance(pytest.data_module, Dataset)
 
 
 def test_permutation():
+    """Checks that retain samples match the order of random permutatio."""
     data_set = QAForgetDataSet(
         _identity,
-        _identity,
+        QAformatter_basic,
         "random",
         random_seed=42,
         loss_type="standard",
+        debug=True,
     )
     init_perm = data_set.retain_permutation
     for idx, ((_, retain_index), (_, _)) in enumerate(data_set):
@@ -29,12 +32,14 @@ def test_permutation():
 
 
 def test_size():
+    """Checking correct dataset size."""
     assert pytest.data_module.__len__() == int(
         pytest.n_questions * pytest.frac_q_dropped
     )
 
 
 def test_formatter():
+    """Check the basic formatter formats Qs and As correctly."""
     test_input = (
         "What is the Answer to the Ultimate Question of Life,\
             The Universe, and Everything?",
@@ -47,8 +52,7 @@ def test_formatter():
 
 
 def test_idk_targets():
-    # check that when using an idk loss, that the targets are correct
-    # for now, no tokenization or formatting
+    """Check that when using an idk loss, that the targets are correct."""
     idk_set = QADataSet(
         _identity,
         _identity,


### PR DESCRIPTION
Initial implementation of the data_modules code from the tofu repo. Currently I test them using an identity function for the tokenizer and in some cases the formatter. There are three, one for returning QA pairs, one for finetuning which returns a formatted Question--Answer pair for autoregression, and one for a forgetting script which returns a formatted retain example and a formatted forget sample. In all cases the forget answer can be replaced with an "idk" type phrase, which is randomly sampled from a .jsonl file.