### PR TITLE
simplify `get_forget_indices`

### DIFF
--- a/src/arcsf/data/tofu.py
+++ b/src/arcsf/data/tofu.py
@@ -1,4 +1,5 @@
 import math
+from typing import Iterable
 
 import numpy as np
 from datasets import Dataset, load_dataset
@@ -14,7 +15,7 @@ def _get_forget_index(author: int, question: int, q_per_author: int) -> int:
 
 
 def get_forget_indices(
-    authors: int | list[int], questions: int | list[int], q_per_author: int
+    authors: int | Iterable[int], questions: int | Iterable[int], q_per_author: int
 ) -> list[int]:
     """
     Returns the question indices in the dataset, given author numbers and within-author
@@ -111,7 +112,7 @@ def load_tofu(
                 forget_indices = []
                 for author in forget_authors:
                     all_author_indices = get_forget_indices(
-                        author, np.arange(q_per_author), q_per_author
+                        author, range(q_per_author), q_per_author
                     )
 
                     _, author_forget_indices = train_test_split(


### PR DESCRIPTION
Slightly modified version to fix what was proposed in the comments of #12 to simplify `get_forget_indices`.

The problem with the one proposed in the PR is that the original `get_forget_indices` returns an `int` if the input questions and authors are both `int` (which is a bug in the return type hints for that function, it should be `list[int] | int` as written). It returning an `int` in that case was relied on in `load_tofu`.

With this change, `get_forget_indices` _always_ returns a `list[int]` and the relevant part of `load_tofu` is updated to reflect that. It also means the `_flatten_list_of_lists` function isn't used anywhere and can be removed, along with `get_author_indices`.